### PR TITLE
compatibility fix

### DIFF
--- a/enjoy_mineral_shards.py
+++ b/enjoy_mineral_shards.py
@@ -1,7 +1,7 @@
 import sys
 
 import baselines.common.tf_util as U
-import gflags as flags
+from absl import flags
 import numpy as np
 from baselines import deepq
 from pysc2.env import environment
@@ -30,8 +30,9 @@ FLAGS = flags.FLAGS
 
 def main():
   FLAGS(sys.argv)
+  #with sc2_env.SC2Env()
   with sc2_env.SC2Env(
-      "CollectMineralShards",
+      map_name="CollectMineralShards",
       step_mul=step_mul,
       visualize=True,
       game_steps_per_episode=steps * step_mul) as env:

--- a/train_mineral_shards.py
+++ b/train_mineral_shards.py
@@ -1,6 +1,6 @@
 import sys
 
-import gflags as flags
+from absl import flags
 from baselines import deepq
 from pysc2.env import sc2_env
 from pysc2.lib import actions
@@ -19,7 +19,7 @@ FLAGS = flags.FLAGS
 def main():
   FLAGS(sys.argv)
   with sc2_env.SC2Env(
-      "CollectMineralShards",
+      map_name="CollectMineralShards",
       step_mul=step_mul,
       visualize=True) as env:
 


### PR DESCRIPTION
Fixing two tiny issues (#1 and #2):
- Arguments for the SC2Env have to be given as keyword arguments.
- gflags fails during the initialization of the SC2Env, but absl.flags works.